### PR TITLE
Add support for pinned posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Jekyll Paper for Github is easy to create your own blog. You can create your blo
 
 You can add new posts at any time after you had your own blog. Create a new post need to add a new file in `_posts` directory, and the file name must follow the convention `YYYY-MM-DD-name-of-post.md`.
 
+### Pin a Post to the Top of the List
+
+If you want a post to stay at the top of the index page, add `pinned: true` to its front matter. Pinned posts are highlighted and remain above the regular reverse-chronological list on the first page of the blog.
+
 ## Custom Navigation Menu
 
 You can add or update navigation menu items in `_data/menus.yml` file. In the configuration file, you need set title and URL for every navigation menu item.

--- a/_data/lang.yml
+++ b/_data/lang.yml
@@ -5,6 +5,7 @@ en:
   paginator_previous: 'Previous'
   paginator_pages: 'Page: '
   paginator_next: 'Next'
+  posts_pinned: 'Pinned'
   notification_404: 'Page not found :('
   post_write_date: 'Written on '
   post_update_date: 'updated at '
@@ -22,6 +23,7 @@ de:
   paginator_previous: 'Bisherige'
   paginator_pages: 'Seite: '
   paginator_next: 'Nächster'
+  posts_pinned: 'Angeheftet'
   notification_404: 'Seite nicht gefunden :('
   post_write_date: 'Geschrieben auf '
   post_update_date: 'aktualisiert am '
@@ -39,6 +41,7 @@ es:
   paginator_previous: 'Anterior'
   paginator_pages: 'Página: '
   paginator_next: 'Siguiente'
+  posts_pinned: 'Fijado'
   notification_404: 'Página no encontrada :('
   post_write_date: 'Escrito en '
   post_update_date: 'actualizado en '
@@ -56,6 +59,7 @@ it:
   paginator_previous: 'Precedente'
   paginator_pages: 'Pagina: '
   paginator_next: 'Successivo'
+  posts_pinned: 'In evidenza'
   notification_404: 'Pagina non trovata :('
   post_write_date: 'Scritto il '
   post_update_date: 'aggiornato il '
@@ -73,6 +77,7 @@ fr:
   paginator_previous: 'Précédent'
   paginator_pages: 'Page: '
   paginator_next: 'Prochain'
+  posts_pinned: 'Épinglé'
   notification_404: 'Page non trouvée :('
   post_write_date: 'Écrit sur '
   post_update_date: 'mis à jour à '
@@ -90,6 +95,7 @@ ja:
   paginator_previous: '前のページ'
   paginator_pages: 'ページ数：'
   paginator_next: '次のページ'
+  posts_pinned: '固定表示'
   notification_404: 'このページは見つかりませんでした：（'
   post_write_date: '公開された：'
   post_update_date: '更新日：'
@@ -107,6 +113,7 @@ pt:
   paginator_previous: 'Anterior'
   paginator_pages: 'Página: '
   paginator_next: 'Próximo'
+  posts_pinned: 'Fixado'
   notification_404: 'Página não encontrada :('
   post_write_date: 'Escrito em '
   post_update_date: 'atualizado em '
@@ -124,6 +131,7 @@ zh-cn:
   paginator_previous: '前一页'
   paginator_pages: '页数：'
   paginator_next: '后一页'
+  posts_pinned: '置顶'
   notification_404: '找不到此页：（'
   post_write_date: '发表于'
   post_update_date: '更新于'
@@ -141,6 +149,7 @@ zh-tw:
   paginator_previous: '前一頁'
   paginator_pages: '頁數：'
   paginator_next: '後一頁'
+  posts_pinned: '置頂'
   notification_404: '找不到此頁：（'
   post_write_date: '發表於'
   post_update_date: '更新於'
@@ -158,6 +167,7 @@ tr:
   paginator_previous: 'Geri'
   paginator_pages: 'Sayfa: '
   paginator_next: 'İleri'
+  posts_pinned: 'Sabitli'
   notification_404: 'Sayfa bulunamadı :('
   post_write_date: 'Yazım tarihi '
   post_update_date: 'Güncellenme tarihi '
@@ -175,6 +185,7 @@ ko:
   paginator_previous: "이전"
   paginator_pages: "페이지: "
   paginator_next: "다음"
+  posts_pinned: "상단 고정"
   notification_404: "페이지를 찾을 수 없습니다:("
   post_write_date: "작성일"
   post_update_date: "업데이트된 날짜"

--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -1,5 +1,27 @@
 <div class="container-posts">
-  {% for post in paginator.posts %}
+  {% assign pinned_posts = site.posts | where: 'pinned', true %}
+  {% if paginator.page == 1 and pinned_posts.size > 0 %}
+  <div class="pinned-posts">
+    <div class="pinned-posts-heading">
+      {{ site.data.lang[site.language].posts_pinned | default: 'Pinned' }}
+    </div>
+    {% for post in pinned_posts %}
+    <div class="posts-list-item pinned">
+      <span class="posts-list-item-name float-left">
+        <a href="{{ post.url }}">{{ post.title }}</a>
+      </span>
+      <span class="posts-list-item-date float-right">
+        {{ post.date | date: '%Y-%m-%d' }}
+      </span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% assign posts_to_show = paginator.posts %}
+  {% if paginator.page == 1 %}
+    {% assign posts_to_show = posts_to_show | where_exp: 'post', 'post.pinned != true' %}
+  {% endif %}
+  {% for post in posts_to_show %}
   <div class="posts-list-item">
     <span class="posts-list-item-name float-left">
       <a href="{{ post.url }}">{{ post.title }}</a>

--- a/_posts/2020-12-31-welcome.markdown
+++ b/_posts/2020-12-31-welcome.markdown
@@ -1,13 +1,14 @@
 ---
 layout: post
 title:  "Rest and Regress: My Blog"
-date:   2025-07-31
+date:   2020-12-31
 last_modified_at: 2025-07-31
 categories: [welcome]
+pinned: true
 ---
 
 This is place for me to collect and post musings on statistics, econometrics, data science - and all other jazz that's related...and maybe sometimes jazz that isn't related.
 
 ## FAQ
 
-- Why is the date of this post 2099-12-31? _So that it always shows as the first/latest post. Hopefully I die before 2099-12-31 so that I never have to update this hack._
+- Why does this post stay at the top? _It's pinned there for easy access — no time-traveling publication dates required anymore._

--- a/_sass/post-list.scss
+++ b/_sass/post-list.scss
@@ -8,9 +8,29 @@
   overflow: hidden;
 }
 
+.posts-list-item.pinned {
+  font-weight: 500;
+}
+
 .posts-list-item-name {
   width: calc(100% - 100px);
   font-weight: 300;
+}
+
+.pinned-posts {
+  margin: 0 0 25px 0;
+  padding: 18px 20px 12px 20px;
+  border-left: 4px solid #0070f3;
+  background: #f5f9ff;
+}
+
+.pinned-posts-heading {
+  margin-bottom: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #004a9f;
 }
 
 .list-pagination {


### PR DESCRIPTION
## Summary
- render a dedicated pinned posts section that surfaces entries marked with `pinned: true`
- style highlighted posts and add translation strings for the pinned label
- document how to pin posts and update the welcome post to use the new feature

## Testing
- `bundle install` *(fails: 403 Forbidden while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d46cca2fd88328b24cd5779c719e1e